### PR TITLE
【バック・フロント】いいね機能の実装 #24

### DIFF
--- a/backend/app/controllers/api/v1/activity_likes_controller.rb
+++ b/backend/app/controllers/api/v1/activity_likes_controller.rb
@@ -1,0 +1,20 @@
+class Api::V1::ActivityLikesController < ApplicationController
+  before_action :authenticate_request
+
+  def index
+    activity = Activity.find(params[:activity_id])
+    render json: { likes_count: activity.likes_count, liked: activity.liked_by?(@current_user) }
+  end
+
+  def create
+    activity = Activity.find(params[:activity_id])
+    @current_user.like_activity(activity)
+    render json: { status: 'success', likes_count: activity.likes_count ,liked: activity.liked_by?(@current_user)}
+  end
+
+  def destroy
+    activity = Activity.find(params[:activity_id])
+    @current_user.unlike_activity(activity)
+    render json: { status: 'success', likes_count: activity.likes_count, liked: activity.liked_by?(@current_user)}
+  end
+end

--- a/backend/app/models/activity.rb
+++ b/backend/app/models/activity.rb
@@ -3,4 +3,12 @@ class Activity < ApplicationRecord
   belongs_to :category
   has_many :activity_likes, dependent: :destroy
   has_many :liked_by_users, through: :activity_likes, source: :user
+
+  def likes_count
+    activity_likes.count
+  end
+
+  def liked_by?(user)
+    activity_likes.exists?(user: user)
+  end
 end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -53,6 +53,18 @@ def latest_status_as_json
   @latest_status_as_json ||= latest_status&.as_json(include: { job: { only: [:name] } })
 end
 
+def like_activity(activity)
+  activity_likes.create(activity: activity)
+end
+
+def unlike_activity(activity)
+  activity_likes.find_by(activity: activity).destroy
+end
+
+def likes?(activity)
+  activity_likes.exists?(activity: activity)
+end
+
 
 
 # 最新のJob名を取得するためのメソッドをUserモデルに追加

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -13,7 +13,9 @@ Rails.application.routes.draw do
 	    # カレントユーザーの呼び出し
       get 'users/current', to: 'users#current'
       resources :jobs, only: [:index]
-      resources :activities, only: [:create]
+      resources :activities, only: [:create] do
+        resources :activity_likes, only: [:index, :create, :destroy]
+      end
       resources :user_statuses, only: [:create]
       resources :items, only: [:index]
       resources :users do

--- a/frontend/src/components/ActivityCard.jsx
+++ b/frontend/src/components/ActivityCard.jsx
@@ -1,0 +1,100 @@
+import React, { useState, useEffect } from "react";
+import { useAuth } from "../providers/auth";
+import { API_URL } from "../config/settings";
+
+const getCategoryBadgeColor = (categoryId) => {
+  switch (categoryId) {
+    case 1:
+      return "badge-primary";
+    case 2:
+      return "badge-secondary";
+    case 3:
+      return "badge-accent";
+    case 4:
+      return "badge-neutral";
+    case 5:
+      return "badge-info";
+    default:
+      return "badge-base-300";
+  }
+};
+
+export const ActivityCard = ({ activity }) => {
+  const { currentUser: authUser, token } = useAuth();
+  const [isLiked, setIsLiked] = useState(false);
+  const categoryBadgeColor = getCategoryBadgeColor(activity.category.id);
+  const [likesCount, setLikesCount] = useState(activity.likes_count);
+
+  useEffect(() => {
+    const fetchLikeStatus = async () => {
+      try {
+        const response = await fetch(
+          `${API_URL}/api/v1/activities/${activity.id}/activity_likes`,
+          {
+            headers: {
+              Authorization: `Bearer ${token}`,
+            },
+          }
+        );
+        if (!response.ok) {
+          throw new Error("いいね情報の取得に失敗しました");
+        }
+        const data = await response.json();
+        setIsLiked(data.liked);
+        setLikesCount(data.likes_count);
+      } catch (error) {
+        console.error("Error fetching like status:", error);
+      }
+    };
+
+    fetchLikeStatus();
+  }, [activity.id, token]);
+
+  const handleLikeClick = async () => {
+    try {
+      const url = isLiked
+        ? `${API_URL}/api/v1/activities/${activity.id}/activity_likes/${activity.id}`
+        : `${API_URL}/api/v1/activities/${activity.id}/activity_likes`;
+      const method = isLiked ? "DELETE" : "POST";
+      const response = await fetch(url, {
+        method,
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+      });
+      if (!response.ok) {
+        throw new Error("いいねの更新に失敗しました");
+      }
+      const data = await response.json();
+      setIsLiked(!isLiked);
+      setLikesCount(data.likes_count);
+    } catch (error) {
+      console.error("Error updating like:", error);
+    }
+  };
+
+  return (
+    <div className="bg-neutral p-4 rounded-lg">
+      <h3 className="text-lg font-bold">{activity.action}</h3>
+      <p>
+        {new Date(activity.created_at).toLocaleDateString()}　{activity.minute}
+        分
+      </p>
+      <div className="mt-2">
+        <span className={`badge ${categoryBadgeColor}`}>
+          {activity.category.name}
+        </span>
+      </div>
+      <div className="mt-4 flex justify-end">
+        <button
+          className={`btn glass btn-sm ${isLiked ? "text-error" : ""}`}
+          onClick={handleLikeClick}
+        >
+          <i className="fas fa-heart mr-2"></i>
+          <span className="text-sm mr-2">{likesCount}</span>
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -75,11 +75,11 @@ export const Header = memo(() => {
       <div className="navbar-end">
         {currentUser && (
           <div className="flex items-center">
-            <span className="text-md mr-2">
+            <span className="text-md mr-2 stat-value">
               <i className="fas fa-coins mr-1"></i>
               {currentUser.coin.amount}
             </span>
-            <span className="text-md mr-2 px-2 bg-secondary rounded-md">
+            <span className="text-lg mr-2 px-2 bg-secondary rounded-md">
               {currentUser.nickname}
             </span>
           </div>

--- a/frontend/src/pages/CreateAvatar.jsx
+++ b/frontend/src/pages/CreateAvatar.jsx
@@ -38,8 +38,7 @@ export const CreateAvatar = () => {
   }, [token]);
 
   const generateAvatar = async () => {
-    const basePrompt =
-      "ドラゴンクエスト風の32bitレトロゲームのキャラクター　背景は無地";
+    const basePrompt = "ドラゴンクエスト風の32bit RPGのキャラクター";
     const prompt = `${basePrompt} ${selectedJob} ${selectedGender} ${selectedSupplement}`;
     try {
       const response = await fetch(

--- a/frontend/src/pages/Users.jsx
+++ b/frontend/src/pages/Users.jsx
@@ -17,6 +17,7 @@ export const Users = () => {
   if (!currentUser) {
     return <p>Loading profile...</p>;
   }
+  console.log(users);
 
   return (
     <div className="container mx-auto p-4">

--- a/frontend/src/pages/UsersShow.jsx
+++ b/frontend/src/pages/UsersShow.jsx
@@ -4,6 +4,7 @@ import { useAuth } from "../providers/auth";
 import { API_URL } from "../config/settings";
 import { Link } from "react-router-dom";
 import { FRONT_URL } from "../config/settings";
+import { ActivityCard } from "../components/ActivityCard";
 
 export const UsersShow = () => {
   const { currentUser } = useAuth();
@@ -20,6 +21,8 @@ export const UsersShow = () => {
   if (!user) {
     return <p>Loading profile...</p>;
   }
+
+  console.log(user);
 
   return (
     <div className="container mx-auto p-4">
@@ -39,7 +42,6 @@ export const UsersShow = () => {
             className="w-full h-auto mb-4 rounded-lg"
           />
         </div>
-
         {/* ステータス */}
         {user.latest_status && (
           <div className="bg-base-200 p-4 rounded-lg">
@@ -58,29 +60,34 @@ export const UsersShow = () => {
             </div>
           </div>
         )}
-
         {/* 歴代アバター */}
         <div className="bg-base-200 p-4 rounded-lg">
           <h2 className="text-xl font-bold mb-2">過去のアバター</h2>
           <div className="grid grid-cols-3 gap-2">
-            {user.avatars.map((avatar) => (
-              <img
-                key={avatar.id}
-                src={`${avatar.avatar_url}`}
-                alt="User Avatar"
-                className="w-full h-auto rounded"
-              />
-            ))}
+            {user.avatars
+              .slice(-9)
+              .reverse()
+              .map((avatar) => (
+                <img
+                  key={avatar.id}
+                  src={`${avatar.avatar_url}`}
+                  alt="User Avatar"
+                  className="w-full h-auto rounded"
+                />
+              ))}
           </div>
         </div>
       </div>
-
       {/* 活動一覧 */}
       <div className="bg-base-200 mt-4 p-4 rounded-lg">
         <h2 className="text-xl font-bold mb-2">活動一覧</h2>
-        {/* 仮のボックスを表示 */}
-        <div className="bg-base-300 h-40 rounded-lg flex items-center justify-center">
-          <p className="text-lg">活動一覧（仮）</p>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          {user.activities
+            .slice(-9)
+            .reverse()
+            .map((activity) => (
+              <ActivityCard key={activity.id} activity={activity} />
+            ))}
         </div>
       </div>
     </div>


### PR DESCRIPTION
### いいね機能の実装
- ユーザー詳細にActivityCardとして外挿
- Railsルーティングおよびコントローラの設定
- likes countをフロントに返すように設定
- いいねカウントを表示するようにした
- currentUserがいいねしている場合はdestroyに切り替わる 