### PR TITLE
【バック】3日連続記録した時にフラグを立てるロジック #77

### DIFF
--- a/backend/app/controllers/api/v1/activities_controller.rb
+++ b/backend/app/controllers/api/v1/activities_controller.rb
@@ -5,6 +5,8 @@ module Api
 
       def create
         activity = @current_user.activities.build(activity_params)
+
+        
         if activity.save
           # ユーザーの連続記録日数、特別モードのアンロック、達成回数を更新
           update_user_status(activity.created_at.to_date)

--- a/backend/app/controllers/api/v1/activities_controller.rb
+++ b/backend/app/controllers/api/v1/activities_controller.rb
@@ -6,6 +6,8 @@ module Api
       def create
         activity = @current_user.activities.build(activity_params)
         if activity.save
+          # ユーザーの連続記録日数、特別モードのアンロック、達成回数を更新
+          update_user_status(activity.created_at.to_date)
           render json: activity, status: :created
         else
           render json: activity.errors, status: :unprocessable_entity
@@ -17,6 +19,32 @@ module Api
       def activity_params
         params.require(:activity).permit(:action, :category_id, :minute)
       end
+
+      def update_user_status(activity_date)
+        last_activity_date = @current_user.activities.order(created_at: :desc).second&.created_at&.to_date
+        last_special_unlocked_date = @current_user.last_special_unlocked_date
+        
+        if @current_user.activities.where(created_at: activity_date.all_day).count > 1
+          # 同じ日付の活動が既に存在する場合は、連続記録日数を加算しない
+          consecutive_days = @current_user.consecutive_days
+        elsif last_activity_date && activity_date == last_activity_date + 1.day
+          # 連続している場合は、連続記録日数を1加算
+          consecutive_days = @current_user.consecutive_days + 1
+        else
+          # 連続していない場合は、連続記録日数を1にリセット
+          consecutive_days = 1
+        end
+        
+        special_mode_unlocked = consecutive_days >= 3 && !@current_user.special_mode_unlocked
+        achievement = special_mode_unlocked ? @current_user.achievement + 1 : @current_user.achievement
+        
+        @current_user.update(
+          consecutive_days: consecutive_days,
+          special_mode_unlocked: special_mode_unlocked,
+          last_special_unlocked_date: special_mode_unlocked ? activity_date : @current_user.last_special_unlocked_date,
+          achievement: achievement
+          )
+        end
+      end
     end
   end
-end

--- a/backend/app/controllers/api/v1/activities_controller.rb
+++ b/backend/app/controllers/api/v1/activities_controller.rb
@@ -27,16 +27,24 @@ module Api
         if @current_user.activities.where(created_at: activity_date.all_day).count > 1
           # 同じ日付の活動が既に存在する場合は、連続記録日数を加算しない
           consecutive_days = @current_user.consecutive_days
-        elsif last_activity_date && activity_date == last_activity_date + 1.day
+          Rails.logger.info("同じ日付の活動が既に存在する場合は、連続記録日数を加算しない")
+        elsif last_activity_date == activity_date - 1.day
           # 連続している場合は、連続記録日数を1加算
           consecutive_days = @current_user.consecutive_days + 1
+          Rails.logger.info("連続している場合は、連続記録日数を1加算")
         else
           # 連続していない場合は、連続記録日数を1にリセット
           consecutive_days = 1
+          Rails.logger.info("連続していない場合は、連続記録日数を1にリセット")
         end
         
         special_mode_unlocked = consecutive_days >= 3 && !@current_user.special_mode_unlocked
         achievement = special_mode_unlocked ? @current_user.achievement + 1 : @current_user.achievement
+
+        if special_mode_unlocked
+          # 特典条件を満たした場合は、consecutive_daysを1にリセット
+          consecutive_days = 0
+        end
         
         @current_user.update(
           consecutive_days: consecutive_days,

--- a/backend/app/controllers/api/v1/special_modes_controller.rb
+++ b/backend/app/controllers/api/v1/special_modes_controller.rb
@@ -1,0 +1,12 @@
+class Api::V1::SpecialModesController < ApplicationController
+  before_action :authenticate_request
+
+  def participate
+    if @current_user.special_mode_unlocked
+      @current_user.update(special_mode_unlocked: false)
+      render json: { message: '魔王戦に挑みます' }, status: :ok
+    else
+      render json: { error: '魔王戦に挑むことができませんでした' }, status: :unprocessable_entity
+    end
+  end
+end

--- a/backend/config/application.rb
+++ b/backend/config/application.rb
@@ -21,7 +21,8 @@ module App
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = 'Asia/Tokyo'
+    config.active_record.default_timezone = :local
     # config.eager_load_paths << Rails.root.join("extras")
     config.middleware.use ActionDispatch::Cookies
     config.middleware.use ActionDispatch::Session::CookieStore, key: 'mao_the_session'

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
     namespace :v1 do
 	    # カレントユーザーの呼び出し
       get 'users/current', to: 'users#current'
+      post '/special_modes/participate', to: 'special_modes#participate'
       resources :jobs, only: [:index]
       resources :activities, only: [:create] do
         resources :activity_likes, only: [:index, :create, :destroy]

--- a/backend/db/migrate/20240512035723_add_columns_to_users.rb
+++ b/backend/db/migrate/20240512035723_add_columns_to_users.rb
@@ -1,0 +1,7 @@
+class AddColumnsToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :consecutive_days, :integer, default: 0
+    add_column :users, :special_mode_unlocked, :boolean, default: false
+    add_column :users, :last_special_unlocked_date, :date
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_29_075739) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_12_035723) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -149,6 +149,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_29_075739) do
     t.integer "achievement"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "consecutive_days", default: 0
+    t.boolean "special_mode_unlocked", default: false
+    t.date "last_special_unlocked_date"
   end
 
   create_table "users_items", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -31,7 +31,7 @@ items = [
   { name: "東国の揚げ鶏", cost: 10, item_url: "imgs/items/item_009.png", category: "道具" },
   { name: "毒消しハーブ", cost: 20, item_url: "imgs/items/item_010.png", category: "道具" },
   { name: "棍棒", cost: 30, item_url: "imgs/items/item_011.png", category: "武器" },
-  { name: "銅の剣", cost: 50, item_url: "imgs/items/tem_012.png", category: "武器" },
+  { name: "銅の剣", cost: 50, item_url: "imgs/items/item_012.png", category: "武器" },
   { name: "鉄の槍", cost: 100, item_url: "imgs/items/item_013.png", category: "武器" },
   { name: "魔法の杖", cost: 100, item_url: "imgs/items/item_014.png", category: "武器" },
   { name: "盗賊のナイフ", cost: 100, item_url: "imgs/items/item_015.png", category: "武器" },

--- a/frontend/src/components/ActivityEntry.jsx
+++ b/frontend/src/components/ActivityEntry.jsx
@@ -150,6 +150,29 @@ const ActivityEntry = ({ currentUser, setCurrentUser }) => {
       !todayActivities.some((activity) => activity.category.id === category.id)
   );
 
+  const handleSpecialModeParticipation = async () => {
+    try {
+      const response = await fetch(
+        `${API_URL}/api/v1/special_modes/participate`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      );
+
+      if (response.ok) {
+        setCurrentUser({ ...currentUser, special_mode_unlocked: false });
+      } else {
+        console.error("魔王戦の参加に失敗しました");
+      }
+    } catch (error) {
+      console.error("エラーが発生しました:", error);
+    }
+  };
+
   return (
     <div
       className={`bg-base-200 p-4 rounded-lg ${
@@ -221,6 +244,15 @@ const ActivityEntry = ({ currentUser, setCurrentUser }) => {
             登録
           </button>
         </div>
+      )}
+      {/*魔王戦のボタン*/}
+      {currentUser.special_mode_unlocked && (
+        <button
+          className="btn btn-secondary mt-4"
+          onClick={handleSpecialModeParticipation}
+        >
+          特別なモードに参加する
+        </button>
       )}
     </div>
   );


### PR DESCRIPTION
1. Usersテーブルに`last_special_unlocked_date(date)` 、`consecutive_days(integer)`　、　`special_mode_unlocked(Boolean)`を追加
2. ユーザーが活動記録した場合現在の日付と最新の活動記録の日付を比較し下記の処理を実施
    - 連続している場合は、`consecutive_days`を1加算
    - 連続していない場合は、`consecutive_days`を1にリセット
3. 同じ日付の活動が既に存在する場合は`consecutive_days`を加算しない（連続日加算は1日一回）
4. `consecutive_days(integer)` が3 以上で`special_mode_unlocked`がfalseの場合、以下の処理
    1. `special_mode_unlocked`をtrueに更新
    2. `last_special_unlocked_date`を現在の日付に設定
    3. `achievement`を1増加
    4. `consecutive_days` を0にする
5. `last_special_unlocked_date`が記録当日と同じ場合、`consecutive_days`は加算されない