### PR TITLE
【フロント】マイページとユーザー詳細でアバター一覧、所持品一覧

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -36,3 +36,18 @@
     transform: rotate(360deg);
   }
 }
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: scale(0.8);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.modal-box {
+  animation: fadeIn 0.3s ease-out;
+}

--- a/frontend/src/pages/MyPage.jsx
+++ b/frontend/src/pages/MyPage.jsx
@@ -321,25 +321,6 @@ export const MyPage = () => {
           )}
         </div>
       </dialog>
-
-      <style>
-        {`
-          @keyframes fadeIn {
-            from {
-              opacity: 0;
-              transform: scale(0.8);
-            }
-            to {
-              opacity: 1;
-              transform: scale(1);
-            }
-          }
-
-          .modal-box {
-            animation: fadeIn 0.3s ease-out;
-          }
-        `}
-      </style>
     </div>
   );
 };

--- a/frontend/src/pages/MyPage.jsx
+++ b/frontend/src/pages/MyPage.jsx
@@ -12,7 +12,8 @@ export const MyPage = () => {
   const [editedNickname, setEditedNickname] = useState("");
   const [isProfileEditing, setIsProfileEditing] = useState(false);
   const [editedProfile, setEditedProfile] = useState("");
-  const [activeTab, setActiveTab] = useState("entry");
+  const [itemsTab, setItemsTab] = useState("items");
+  const [activitiesTab, setActivitiesTab] = useState("entry");
   const [showAllItems, setShowAllItems] = useState(false);
   const [showAllAvatars, setShowAllAvatars] = useState(false);
 
@@ -85,7 +86,6 @@ export const MyPage = () => {
   if (!currentUser) {
     return <p>Loading profile...</p>;
   }
-  console.log(currentUser);
 
   return (
     <div className="container mx-auto p-4">
@@ -173,20 +173,20 @@ export const MyPage = () => {
           <div role="tablist" className="tabs tabs-lifted mb-4">
             <a
               role="tab"
-              className={`tab ${activeTab === "items" ? "tab-active" : ""}`}
-              onClick={() => setActiveTab("items")}
+              className={`tab ${itemsTab === "items" ? "tab-active" : ""}`}
+              onClick={() => setItemsTab("items")}
             >
               所持品
             </a>
             <a
               role="tab"
-              className={`tab ${activeTab === "avatars" ? "tab-active" : ""}`}
-              onClick={() => setActiveTab("avatars")}
+              className={`tab ${itemsTab === "avatars" ? "tab-active" : ""}`}
+              onClick={() => setItemsTab("avatars")}
             >
               アバター
             </a>
           </div>
-          {activeTab === "items" ? (
+          {itemsTab === "items" ? (
             <>
               <h2 className="text-xl font-bold mb-4 cursor-pointer">所持品</h2>
               {currentUser.users_items.length > 0 ? (
@@ -195,7 +195,7 @@ export const MyPage = () => {
                     {currentUser.users_items
                       .slice(
                         0,
-                        showAllItems ? currentUser.users_items.length : 5
+                        showAllItems ? currentUser.users_items.length : 3
                       )
                       .map((userItem, index) => (
                         <div key={index} className="py-4 relative">
@@ -217,7 +217,7 @@ export const MyPage = () => {
                         </div>
                       ))}
                   </div>
-                  {currentUser.users_items.length > 5 && (
+                  {currentUser.users_items.length > 3 && (
                     <button
                       className="mt-4 text-primary underline"
                       onClick={() => setShowAllItems(!showAllItems)}
@@ -275,20 +275,20 @@ export const MyPage = () => {
         <div role="tablist" className="tabs tabs-lifted mb-4">
           <a
             role="tab"
-            className={`tab ${activeTab === "entry" ? "tab-active" : ""}`}
-            onClick={() => setActiveTab("entry")}
+            className={`tab ${activitiesTab === "entry" ? "tab-active" : ""}`}
+            onClick={() => setActivitiesTab("entry")}
           >
             今日の活動登録
           </a>
           <a
             role="tab"
-            className={`tab ${activeTab === "show" ? "tab-active" : ""}`}
-            onClick={() => setActiveTab("show")}
+            className={`tab ${activitiesTab === "show" ? "tab-active" : ""}`}
+            onClick={() => setActivitiesTab("show")}
           >
             これまでの活動履歴
           </a>
         </div>
-        {activeTab === "entry" ? (
+        {activitiesTab === "entry" ? (
           <ActivityEntry
             currentUser={currentUser}
             setCurrentUser={setCurrentUser}

--- a/frontend/src/pages/MyPage.jsx
+++ b/frontend/src/pages/MyPage.jsx
@@ -13,6 +13,8 @@ export const MyPage = () => {
   const [isProfileEditing, setIsProfileEditing] = useState(false);
   const [editedProfile, setEditedProfile] = useState("");
   const [activeTab, setActiveTab] = useState("entry");
+  const [showAllItems, setShowAllItems] = useState(false);
+  const [showAllAvatars, setShowAllAvatars] = useState(false);
 
   useEffect(() => {
     setCurrentUser(authUser);
@@ -166,14 +168,107 @@ export const MyPage = () => {
             </div>
           </div>
         )}
-        {/* 所持品 */}
+        {/* 所持品とアバター */}
         <div className="bg-base-200 p-4 rounded-lg">
-          <h2 className="text-xl font-bold mb-2">所持品</h2>
-          {/* 仮のボックスを表示 */}
-          <div className="bg-base-300 h-40 rounded-lg flex items-center justify-center">
-            <p className="text-lg">データがありません</p>
+          <div role="tablist" className="tabs tabs-lifted mb-4">
+            <a
+              role="tab"
+              className={`tab ${activeTab === "items" ? "tab-active" : ""}`}
+              onClick={() => setActiveTab("items")}
+            >
+              所持品
+            </a>
+            <a
+              role="tab"
+              className={`tab ${activeTab === "avatars" ? "tab-active" : ""}`}
+              onClick={() => setActiveTab("avatars")}
+            >
+              アバター
+            </a>
           </div>
+          {activeTab === "items" ? (
+            <>
+              <h2 className="text-xl font-bold mb-4 cursor-pointer">所持品</h2>
+              {currentUser.users_items.length > 0 ? (
+                <>
+                  <div className="flex flex-col divide-y divide-base-300">
+                    {currentUser.users_items
+                      .slice(
+                        0,
+                        showAllItems ? currentUser.users_items.length : 5
+                      )
+                      .map((userItem, index) => (
+                        <div key={index} className="py-4 relative">
+                          <div className="badge badge-primary absolute right-2 top-2">
+                            {userItem.amount}
+                          </div>
+                          <div className="flex items-center space-x-4">
+                            <img
+                              src={userItem.item.item_url}
+                              alt={userItem.item.name}
+                              className="w-16 h-16 object-contain"
+                            />
+                            <div>
+                              <h3 className="text-lg font-medium">
+                                {userItem.item.name}
+                              </h3>
+                            </div>
+                          </div>
+                        </div>
+                      ))}
+                  </div>
+                  {currentUser.users_items.length > 5 && (
+                    <button
+                      className="mt-4 text-primary underline"
+                      onClick={() => setShowAllItems(!showAllItems)}
+                    >
+                      {showAllItems ? "一部を表示" : "すべて表示"}
+                    </button>
+                  )}
+                </>
+              ) : (
+                <div className="h-40 flex items-center justify-center">
+                  <p className="text-lg">データがありません</p>
+                </div>
+              )}
+            </>
+          ) : (
+            <>
+              <h2 className="text-xl font-bold mb-4 cursor-pointer">
+                アバター
+              </h2>
+              {currentUser.avatars.length > 0 ? (
+                <>
+                  <div className="grid grid-cols-3 gap-2">
+                    {currentUser.avatars
+                      .slice(0, showAllAvatars ? currentUser.avatars.length : 9)
+                      .map((avatar) => (
+                        <img
+                          key={avatar.id}
+                          src={`${avatar.avatar_url}`}
+                          alt="User Avatar"
+                          className="w-full h-auto rounded"
+                        />
+                      ))}
+                  </div>
+                  {currentUser.avatars.length > 9 && (
+                    <button
+                      className="mt-4 text-primary underline"
+                      onClick={() => setShowAllAvatars(!showAllAvatars)}
+                    >
+                      {showAllAvatars ? "一部を表示" : "すべて表示"}
+                    </button>
+                  )}
+                </>
+              ) : (
+                <div className="h-40 flex items-center justify-center">
+                  <p className="text-lg">データがありません</p>
+                </div>
+              )}
+            </>
+          )}
         </div>
+        {/* ここまで所持品とアバター */}
       </div>
       {/* 活動報告 */}
       <div className="bg-base-200 mt-4 p-4 rounded-lg">

--- a/frontend/src/pages/MyPage.jsx
+++ b/frontend/src/pages/MyPage.jsx
@@ -133,6 +133,7 @@ export const MyPage = () => {
           <div className="bg-base-200 p-4 rounded-lg">
             <h2 className="text-xl font-bold mb-2">ステータス</h2>
             <p>Level: {currentUser.latest_status.level}</p>
+            <p>{currentUser.latest_status.job.name}</p>
             <p>HP: {currentUser.latest_status.hp}</p>
             <p>体力: {currentUser.latest_status.strength}</p>
             <p>知力: {currentUser.latest_status.intelligence}</p>

--- a/frontend/src/pages/MyPage.jsx
+++ b/frontend/src/pages/MyPage.jsx
@@ -16,6 +16,7 @@ export const MyPage = () => {
   const [activitiesTab, setActivitiesTab] = useState("entry");
   const [showAllItems, setShowAllItems] = useState(false);
   const [showAllAvatars, setShowAllAvatars] = useState(false);
+  const [selectedAvatar, setSelectedAvatar] = useState(null);
 
   useEffect(() => {
     setCurrentUser(authUser);
@@ -247,7 +248,11 @@ export const MyPage = () => {
                           key={avatar.id}
                           src={`${avatar.avatar_url}`}
                           alt="User Avatar"
-                          className="w-full h-auto rounded"
+                          className="w-full h-auto rounded cursor-pointer"
+                          onClick={() => {
+                            setSelectedAvatar(avatar);
+                            document.getElementById("avatarModal").showModal();
+                          }}
                         />
                       ))}
                   </div>
@@ -297,6 +302,44 @@ export const MyPage = () => {
           <ActivityShow activities={currentUser.activities} />
         )}
       </div>
+
+      {/* アバターモーダル */}
+      <dialog id="avatarModal" className="modal">
+        <div className="modal-box relative">
+          <button
+            className="btn btn-sm btn-circle absolute right-2 top-2"
+            onClick={() => document.getElementById("avatarModal").close()}
+          >
+            ✕
+          </button>
+          {selectedAvatar && (
+            <img
+              src={`${selectedAvatar.avatar_url}`}
+              alt="Selected Avatar"
+              className="w-full h-auto rounded"
+            />
+          )}
+        </div>
+      </dialog>
+
+      <style>
+        {`
+          @keyframes fadeIn {
+            from {
+              opacity: 0;
+              transform: scale(0.8);
+            }
+            to {
+              opacity: 1;
+              transform: scale(1);
+            }
+          }
+
+          .modal-box {
+            animation: fadeIn 0.3s ease-out;
+          }
+        `}
+      </style>
     </div>
   );
 };

--- a/frontend/src/pages/UsersShow.jsx
+++ b/frontend/src/pages/UsersShow.jsx
@@ -10,6 +10,7 @@ export const UsersShow = () => {
   const { currentUser } = useAuth();
   const { id } = useParams();
   const [user, setUser] = useState(null);
+  const [selectedAvatar, setSelectedAvatar] = useState(null);
 
   useEffect(() => {
     fetch(`${API_URL}/api/v1/users/${id}`)
@@ -21,8 +22,6 @@ export const UsersShow = () => {
   if (!user) {
     return <p>Loading profile...</p>;
   }
-
-  console.log(user);
 
   return (
     <div className="container mx-auto p-4">
@@ -72,7 +71,11 @@ export const UsersShow = () => {
                   key={avatar.id}
                   src={`${avatar.avatar_url}`}
                   alt="User Avatar"
-                  className="w-full h-auto rounded"
+                  className="w-full h-auto rounded cursor-pointer"
+                  onClick={() => {
+                    setSelectedAvatar(avatar);
+                    document.getElementById("avatarModal").showModal();
+                  }}
                 />
               ))}
           </div>
@@ -90,6 +93,25 @@ export const UsersShow = () => {
             ))}
         </div>
       </div>
+
+      {/* アバターモーダル */}
+      <dialog id="avatarModal" className="modal">
+        <div className="modal-box relative">
+          <button
+            className="btn btn-sm btn-circle absolute right-2 top-2"
+            onClick={() => document.getElementById("avatarModal").close()}
+          >
+            ✕
+          </button>
+          {selectedAvatar && (
+            <img
+              src={`${selectedAvatar.avatar_url}`}
+              alt="Selected Avatar"
+              className="w-full h-auto rounded"
+            />
+          )}
+        </div>
+      </dialog>
     </div>
   );
 };

--- a/frontend/src/pages/UsersShow.jsx
+++ b/frontend/src/pages/UsersShow.jsx
@@ -46,6 +46,7 @@ export const UsersShow = () => {
           <div className="bg-base-200 p-4 rounded-lg">
             <h2 className="text-xl font-bold mb-2">ステータス</h2>
             <p>Level: {user.latest_status.level}</p>
+            <p>{user.latest_status.job.name}</p>
             <p>HP: {user.latest_status.hp}</p>
             <p>体力: {user.latest_status.strength}</p>
             <p>知力: {user.latest_status.intelligence}</p>


### PR DESCRIPTION
- マイページで所持品一覧を表示。3件のみ表示してあとはトグル展開
- マイページでアバター一覧表示。9件のみ表示してあとはトグル展開。クリックしたらモーダルで画像表示
- ユーザー詳細ページのアバター一覧をクリックするとモーダルで画像表示