### PR TITLE
【フロント】ステータス画面に説明補足追加 #112

### DIFF
--- a/frontend/src/components/ActivityEntry.jsx
+++ b/frontend/src/components/ActivityEntry.jsx
@@ -21,12 +21,12 @@ const categories = [
   {
     id: 4,
     name: "仕事",
-    description: "アルバイトや業務など。素早さを向上させます",
+    description: "アルバイトや業務など。敏捷を向上させます",
   },
   {
     id: 5,
     name: "娯楽",
-    description: "趣味や遊びなど。カリスマを向上させます",
+    description: "趣味や遊びなど。魅力を向上させます",
   },
 ];
 
@@ -246,7 +246,7 @@ const ActivityEntry = ({ currentUser, setCurrentUser }) => {
           </div>
           <div
             className="flex items-center mb-2 relative tooltip"
-            data-tip="活動時間を指定してください（0〜600分）"
+            data-tip="活動時間を指定してください（0〜600分）　長さはステータスの上昇度に影響しません"
           >
             <input
               type="range"

--- a/frontend/src/pages/Battle.jsx
+++ b/frontend/src/pages/Battle.jsx
@@ -131,7 +131,7 @@ export const Battle = () => {
       ) + 1;
     const playerMagic =
       Math.floor(
-        Math.random() * ((currentUser.latest_status.strength + 10) * 2)
+        Math.random() * ((currentUser.latest_status.intelligence + 10) * 2.2)
       ) + 1;
     const playerDamage =
       attackType === "attack"

--- a/frontend/src/pages/Boss.jsx
+++ b/frontend/src/pages/Boss.jsx
@@ -82,6 +82,19 @@ export const Boss = () => {
     }
   }, [currentUser, battleChecked]);
 
+  useEffect(() => {
+    if (currentUser && currentUser.boss_battle_logs && !battleChecked) {
+      const today = new Date().toISOString().slice(0, 10);
+      const hasTodaysBattleLog = currentUser.boss_battle_logs.some((log) => {
+        return log.created_at.slice(0, 10) === today;
+      });
+      if (hasTodaysBattleLog) {
+        setGameOver(true);
+      }
+      setBattleChecked(true);
+    }
+  }, [currentUser, battleChecked]);
+
   const saveBattleLog = async (result, damage) => {
     if (!currentUser || !boss) return;
     try {
@@ -155,7 +168,7 @@ export const Boss = () => {
       ) + 1;
     const playerMagic =
       Math.floor(
-        Math.random() * ((currentUser.latest_status.strength + 10) * 2)
+        Math.random() * ((currentUser.latest_status.intelligence + 10) * 2)
       ) + 1;
     const playerDamage =
       attackType === "attack"

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -56,6 +56,7 @@ export const HomePage = () => {
             />
           </div>
           <div className="flex flex-col justify-center">
+            <p className="text-md mb-2">習慣化支援RPG</p>
             <h2 className="text-4xl font-bold mb-4">3日目に魔王がいる</h2>
             <p className="text-xl mb-8">MAO the 3rd Day</p>
             <div className="space-y-4">

--- a/frontend/src/pages/MyPage.jsx
+++ b/frontend/src/pages/MyPage.jsx
@@ -17,12 +17,21 @@ export const MyPage = () => {
   const [showAllItems, setShowAllItems] = useState(false);
   const [showAllAvatars, setShowAllAvatars] = useState(false);
   const [selectedAvatar, setSelectedAvatar] = useState(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   useEffect(() => {
     setCurrentUser(authUser);
     setEditedNickname(authUser?.nickname || "");
     setEditedProfile(authUser?.profile || "");
   }, [authUser]);
+
+  const openModal = () => {
+    setIsModalOpen(true);
+  };
+
+  const closeModal = () => {
+    setIsModalOpen(false);
+  };
 
   const handleNicknameEditClick = () => {
     setIsNicknameEditing(true);
@@ -31,6 +40,7 @@ export const MyPage = () => {
   const handleProfileEditClick = () => {
     setIsProfileEditing(true);
   };
+
   const handleNicknameSaveClick = async () => {
     try {
       const response = await fetch(
@@ -178,8 +188,13 @@ export const MyPage = () => {
         </div>
         {/* ステータス */}
         {currentUser.latest_status && (
-          <div className="bg-base-200 p-4 rounded-lg">
-            <h2 className="text-xl font-bold mb-2">ステータス</h2>
+          <div className="bg-base-200 p-4 rounded-lg relative">
+            <h2 className="text-xl font-bold mb-2 flex items-center">
+              ステータス
+              <button onClick={openModal} className="ml-2 text-blue-500">
+                <i className="fas fa-question-circle"></i>
+              </button>
+            </h2>
             <p>Level: {currentUser.latest_status.level}</p>
             <p>{currentUser.latest_status.job.name}</p>
             <p>HP: {currentUser.latest_status.hp}</p>
@@ -386,6 +401,26 @@ export const MyPage = () => {
           )}
         </div>
       </dialog>
+
+      {/* ステータスモーダル */}
+      {isModalOpen && (
+        <div className="fixed inset-0 flex items-center justify-center bg-base-100 bg-opacity-60 z-50">
+          <div className="bg-base-100 p-4 rounded-lg max-w-md w-full">
+            <h2 className="text-xl font-bold mb-2">ステータス説明</h2>
+            <p>Level: 出現モンスターレベルに影響します（予定）</p>
+            <p>筋力: 物理的な攻撃力と防御力に影響します</p>
+            <p>知力: 魔法攻撃力に影響します</p>
+            <p>精神: 防御力に影響します</p>
+            <p>敏捷: ダブルアタック発生率に影響します</p>
+            <p>魅力: 獲得金貨にボーナスがつきます</p>
+            <button className="mt-4 btn btn-primary" onClick={closeModal}>
+              閉じる
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 };
+
+export default MyPage;


### PR DESCRIPTION
- マイページにステータス説明をモーダルで表示
- ゲームバランスを一部修正：魔法のダメージ倍率を0.2倍向上
- タイトル画面を一部修正：習慣化支援RPGを追加