### PR TITLE
活動登録とアバター生成の一連の処理をバックのtransactionに変更

### DIFF
--- a/backend/app/controllers/api/v1/avatars_controller.rb
+++ b/backend/app/controllers/api/v1/avatars_controller.rb
@@ -3,28 +3,38 @@ module Api
     class AvatarsController < ApplicationController
       before_action :set_user
 
+      # トランザクションでアイテム消費とアバター生成を同時に行う
       def create
-        prompt = avatar_params[:prompt]
-        job_id = avatar_params[:job_id]
-        image_url = ChatgptService.download_image(prompt)
-        avatar = @user.avatars.create(avatar_url: image_url)
-        @user.current_avatar_url = image_url
-        if @user.save
-          # userの直近のステータスのジョブを変更する
-          user_status = @user.user_statuses.last || @user.user_statuses.new
-          user_status.update(job_id: job_id)
-          
-          if avatar.persisted?
-            render json: avatar, status: :created
+        ActiveRecord::Base.transaction do
+          item = Item.find(params[:item_id])
+          user_item = @user.users_items.find_by(item_id: item.id)
+          if user_item && user_item.amount > 0
+            user_item.amount -= 1
+            if user_item.amount <= 0
+              user_item.destroy
+            else
+              user_item.save!
+            end
           else
-            render json: avatar.errors, status: :unprocessable_entity
+            raise ActiveRecord::Rollback, "アイテムが不足しています"
           end
-        else
-          logger.error @user.errors.full_messages.to_sentence
-          render json: { errors: @user.errors.full_messages }, status: :unprocessable_entity
-        end
-      end
 
+          prompt = avatar_params[:prompt]
+          job_id = avatar_params[:job_id]
+          image_url = ChatgptService.download_image(prompt)
+          avatar = @user.avatars.create(avatar_url: image_url)
+          @user.current_avatar_url = image_url
+          if @user.save
+            user_status = @user.user_statuses.last || @user.user_statuses.new
+            user_status.update(job_id: job_id)
+            render json: @user.as_json(include: [coin: { only: [:amount] }, items: { only: [:id, :name, :cost, :item_url, :category] }, avatars: { only: [:id, :avatar_url] }]), status: :created
+          else
+            raise ActiveRecord::Rollback, "アバターの生成に失敗しました"
+          end
+        end
+      rescue ActiveRecord::Rollback => e
+        render json: { error: e.message }, status: :unprocessable_entity
+      end
 
       private
 
@@ -33,9 +43,8 @@ module Api
       end
 
       def avatar_params
-        params.permit(:prompt, :job_id, :user_id)
+        params.permit(:prompt, :job_id, :item_id, :user_id)
       end
     end
   end
 end
-

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -96,6 +96,24 @@ def likes?(activity)
   activity_likes.exists?(activity: activity)
 end
 
+#コイン獲得のクラスメソッド
+def gain_coins(base_amount)
+    charisma_bonus = latest_status.charisma * 0.01
+    total_amount = (base_amount * (1 + charisma_bonus)).floor
+
+    logger.info "Base amount: #{base_amount}"
+    logger.info "Charisma bonus: #{charisma_bonus}"
+    logger.info "Total amount: #{total_amount}"
+
+    coin.amount += total_amount
+
+    if coin.save
+      total_amount
+    else
+      raise ActiveRecord::RecordInvalid, coin.errors.full_messages.join(', ')
+    end
+  end
+
 
 
 # 最新のJob名を取得するためのメソッドをUserモデルに追加

--- a/frontend/src/components/ActivityEntry.jsx
+++ b/frontend/src/components/ActivityEntry.jsx
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
 import { API_URL } from "../config/settings";
 import { useAuth } from "../providers/auth";
-import { gainCoins } from "../services/GainCoins"; //コイン獲得メソッド
 
 const categories = [
   {
@@ -60,9 +59,113 @@ const ActivityEntry = ({ currentUser, setCurrentUser }) => {
   const [gainedCoins, setGainedCoins] = useState(null); // 獲得したコインの状態管理
   const [gameLog, setGameLog] = useState([""]); // ゲームログの状態管理
 
+  // const handleSubmit = async () => {
+  //   try {
+  //     const response = await fetch(`${API_URL}/api/v1/activities`, {
+  //       method: "POST",
+  //       headers: {
+  //         "Content-Type": "application/json",
+  //         Authorization: `Bearer ${token}`,
+  //       },
+  //       body: JSON.stringify({
+  //         activity: {
+  //           action: activity.action,
+  //           minute: activity.duration,
+  //           category_id: activity.category_id,
+  //           user_id: currentUser.id,
+  //         },
+  //       }),
+  //     });
 
+  //     if (!response.ok) {
+  //       throw new Error("活動の登録に失敗しました");
+  //     }
+
+  //     const createdActivity = await response.json();
+
+  //     const userStatusResponse = await fetch(
+  //       `${API_URL}/api/v1/user_statuses`,
+  //       {
+  //         method: "POST",
+  //         headers: {
+  //           "Content-Type": "application/json",
+  //           Authorization: `Bearer ${token}`,
+  //         },
+  //         body: JSON.stringify({
+  //           user_status: {
+  //             user_id: currentUser.id,
+  //             job_id: currentUser.latest_status.job_id,
+  //             level: currentUser.latest_status.level + 1,
+  //             hp: currentUser.latest_status.hp + 5,
+  //             strength:
+  //               currentUser.latest_status.strength +
+  //               (createdActivity.category_id === 1 ? 1 : 0),
+  //             intelligence:
+  //               currentUser.latest_status.intelligence +
+  //               (createdActivity.category_id === 2 ? 1 : 0),
+  //             wisdom:
+  //               currentUser.latest_status.wisdom +
+  //               (createdActivity.category_id === 3 ? 1 : 0),
+  //             dexterity:
+  //               currentUser.latest_status.dexterity +
+  //               (createdActivity.category_id === 4 ? 1 : 0),
+  //             charisma:
+  //               currentUser.latest_status.charisma +
+  //               (createdActivity.category_id === 5 ? 1 : 0),
+  //           },
+  //         }),
+  //       }
+  //     );
+
+  //     if (!userStatusResponse.ok) {
+  //       throw new Error("ステータスのアップデートに失敗しました");
+  //     }
+
+  //     const amounts = [10, 20, 30];
+  //     const amount = amounts[Math.floor(Math.random() * amounts.length)];
+  //     const gainedCoins = await gainCoins(
+  //       currentUser,
+  //       token,
+  //       amount,
+  //       setCurrentUser,
+  //       setGainedCoins,
+  //       setGameLog
+  //     ); // 金貨を獲得
+
+  //     setActivity({ action: "", duration: 0, category_id: "" });
+
+  //     const userResponse = await fetch(
+  //       `${API_URL}/api/v1/users/${currentUser.id}`,
+  //       {
+  //         headers: {
+  //           Authorization: `Bearer ${token}`,
+  //         },
+  //       }
+  //     );
+  //     const updatedUser = await userResponse.json();
+  //     setCurrentUser(updatedUser);
+
+  //     let message = "ステータスが向上しました！";
+  //     if (gainedCoins) {
+  //       message += ` ${gainedCoins}枚の金貨を獲得しました！`;
+  //     }
+  //     if (updatedUser.special_mode_unlocked) {
+  //       message += " 魔王が現れた！";
+  //     }
+
+  //     setModalMessage(message);
+  //     setShowModal(true);
+  //   } catch (error) {
+  //     console.error("ユーザーステータスの更新に失敗しました:", error);
+  //   }
+  // };
+  //
+  // transaction処理に変更
   const handleSubmit = async () => {
     try {
+      const amounts = [10, 20, 30];
+      const base_amount = amounts[Math.floor(Math.random() * amounts.length)];
+
       const response = await fetch(`${API_URL}/api/v1/activities`, {
         method: "POST",
         headers: {
@@ -74,8 +177,28 @@ const ActivityEntry = ({ currentUser, setCurrentUser }) => {
             action: activity.action,
             minute: activity.duration,
             category_id: activity.category_id,
-            user_id: currentUser.id,
           },
+          user_status: {
+            job_id: currentUser.latest_status.job_id,
+            level: currentUser.latest_status.level + 1,
+            hp: currentUser.latest_status.hp + 5,
+            strength:
+              currentUser.latest_status.strength +
+              (activity.category_id === 1 ? 1 : 0),
+            intelligence:
+              currentUser.latest_status.intelligence +
+              (activity.category_id === 2 ? 1 : 0),
+            wisdom:
+              currentUser.latest_status.wisdom +
+              (activity.category_id === 3 ? 1 : 0),
+            dexterity:
+              currentUser.latest_status.dexterity +
+              (activity.category_id === 4 ? 1 : 0),
+            charisma:
+              currentUser.latest_status.charisma +
+              (activity.category_id === 5 ? 1 : 0),
+          },
+          base_amount: base_amount,
         }),
       });
 
@@ -83,56 +206,9 @@ const ActivityEntry = ({ currentUser, setCurrentUser }) => {
         throw new Error("活動の登録に失敗しました");
       }
 
-      const createdActivity = await response.json();
-
-      const userStatusResponse = await fetch(
-        `${API_URL}/api/v1/user_statuses`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${token}`,
-          },
-          body: JSON.stringify({
-            user_status: {
-              user_id: currentUser.id,
-              job_id: currentUser.latest_status.job_id,
-              level: currentUser.latest_status.level + 1,
-              hp: currentUser.latest_status.hp + 5,
-              strength:
-                currentUser.latest_status.strength +
-                (createdActivity.category_id === 1 ? 1 : 0),
-              intelligence:
-                currentUser.latest_status.intelligence +
-                (createdActivity.category_id === 2 ? 1 : 0),
-              wisdom:
-                currentUser.latest_status.wisdom +
-                (createdActivity.category_id === 3 ? 1 : 0),
-              dexterity:
-                currentUser.latest_status.dexterity +
-                (createdActivity.category_id === 4 ? 1 : 0),
-              charisma:
-                currentUser.latest_status.charisma +
-                (createdActivity.category_id === 5 ? 1 : 0),
-            },
-          }),
-        }
-      );
-
-      if (!userStatusResponse.ok) {
-        throw new Error("ステータスのアップデートに失敗しました");
-      }
-      
-      const amounts = [10, 20, 30];
-      const amount = amounts[Math.floor(Math.random() * amounts.length)];
-      const gainedCoins = await gainCoins(
-        currentUser,
-        token,
-        amount,
-        setCurrentUser,
-        setGainedCoins,
-        setGameLog
-      ); // 金貨を獲得
+      const data = await response.json();
+      const createdActivity = data.activity;
+      const gainedCoins = data.gained_coins;
 
       setActivity({ action: "", duration: 0, category_id: "" });
 
@@ -162,10 +238,12 @@ const ActivityEntry = ({ currentUser, setCurrentUser }) => {
     }
   };
 
-  const todayActivities = currentUser.activities.filter(
-    (activity) =>
-      new Date(activity.created_at).toDateString() === today.toDateString()
-  );
+  const todayActivities = currentUser.activities
+    ? currentUser.activities.filter(
+        (activity) =>
+          new Date(activity.created_at).toDateString() === today.toDateString()
+      )
+    : [];
 
   const isActivityLimitReached = todayActivities.length >= 3;
 
@@ -173,30 +251,6 @@ const ActivityEntry = ({ currentUser, setCurrentUser }) => {
     (category) =>
       !todayActivities.some((activity) => activity.category.id === category.id)
   );
-
-  const handleSpecialModeParticipation = async () => {
-    try {
-      const response = await fetch(
-        `${API_URL}/api/v1/special_modes/participate`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${token}`,
-          },
-        }
-      );
-
-      if (response.ok) {
-        setCurrentUser({ ...currentUser, special_mode_unlocked: false });
-        window.location.href = "/boss";
-      } else {
-        console.error("魔王戦の参加に失敗しました");
-      }
-    } catch (error) {
-      console.error("エラーが発生しました:", error);
-    }
-  };
 
   return (
     <div

--- a/frontend/src/pages/CreateAvatar.jsx
+++ b/frontend/src/pages/CreateAvatar.jsx
@@ -91,6 +91,65 @@ export const CreateAvatar = () => {
     }
   }, [availableJobs]);
 
+  // const generateAvatar = async () => {
+  //   setLoadingAvatar(true);
+  //   closeConfirmationModal();
+  //   const basePrompt =
+  //     "A pixel art image resembling a 32-bit era video game, depicting a fantasy RPG character. The character is designed with a highly detailed and vibrant pixel art style typical of the 32-bit era, featuring a complex color palette and intricate details, surpassing the 16-bit graphics. The character is in a dynamic pose, equipped with gear appropriate to their job, reflecting their role and abilities in the game. This showcases the advanced graphical capabilities and the spirit of epic adventures in more modern classic video games.";
+  //   const prompt = `${basePrompt} Job: ${selectedJob}, Gender: ${selectedGender}, Age: ${selectedAge}, Personality: ${selectedSupplement}, Race: ${selectedRace}, Accessory: ${selectedAccessory}`;
+  //   const job_id = jobs.find((job) => job.name === selectedJob).id;
+  //   const item_id = jobs.find((job) => job.id === job_id).item_id;
+  //   try {
+  //     //アイテム消費
+  //     const deleteItemResponse = await fetch(
+  //       `${API_URL}/api/v1/users/${currentUser.id}/items/${item_id}/consume`,
+  //       {
+  //         method: "POST",
+  //         headers: {
+  //           Authorization: `Bearer ${token}`,
+  //         },
+  //       }
+  //     );
+
+  //     if (deleteItemResponse.ok) {
+  //       const updatedUser = await deleteItemResponse.json();
+  //       setCurrentUser(updatedUser);
+  //     } else {
+  //       console.error(
+  //         "アイテム消費処理に失敗しました:",
+  //         deleteItemResponse.statusText
+  //       );
+  //     }
+  //     const response = await fetch(
+  //       `${API_URL}/api/v1/users/${currentUser.id}/avatars`,
+  //       {
+  //         method: "POST",
+  //         headers: {
+  //           "Content-Type": "application/json",
+  //           Authorization: `Bearer ${token}`,
+  //         },
+  //         body: JSON.stringify({ prompt, job_id }),
+  //       }
+  //     );
+  //     const avatar = await response.json();
+  //     setGeneratedAvatar(avatar.avatar_url);
+
+  //     // 新しいアバターURLをユーザー情報に反映
+  //     setCurrentUser((prevUser) => ({
+  //       ...prevUser,
+  //       avatars: [...prevUser.avatars, avatar],
+  //       current_avatar_url: avatar.avatar_url,
+  //     }));
+
+  //     setSelectedJob("未選択");
+  //   } catch (error) {
+  //     console.error("アバター生成に失敗しました:", error);
+  //   } finally {
+  //     setLoadingAvatar(false);
+  //   }
+  // };
+
+  // transaction処理に変更
   const generateAvatar = async () => {
     setLoadingAvatar(true);
     closeConfirmationModal();
@@ -99,27 +158,8 @@ export const CreateAvatar = () => {
     const prompt = `${basePrompt} Job: ${selectedJob}, Gender: ${selectedGender}, Age: ${selectedAge}, Personality: ${selectedSupplement}, Race: ${selectedRace}, Accessory: ${selectedAccessory}`;
     const job_id = jobs.find((job) => job.name === selectedJob).id;
     const item_id = jobs.find((job) => job.id === job_id).item_id;
-    try {
-      //アイテム消費
-      const deleteItemResponse = await fetch(
-        `${API_URL}/api/v1/users/${currentUser.id}/items/${item_id}/consume`,
-        {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        }
-      );
 
-      if (deleteItemResponse.ok) {
-        const updatedUser = await deleteItemResponse.json();
-        setCurrentUser(updatedUser);
-      } else {
-        console.error(
-          "アイテム消費処理に失敗しました:",
-          deleteItemResponse.statusText
-        );
-      }
+    try {
       const response = await fetch(
         `${API_URL}/api/v1/users/${currentUser.id}/avatars`,
         {
@@ -128,22 +168,22 @@ export const CreateAvatar = () => {
             "Content-Type": "application/json",
             Authorization: `Bearer ${token}`,
           },
-          body: JSON.stringify({ prompt, job_id }),
+          body: JSON.stringify({ prompt, job_id, item_id }),
         }
       );
-      const avatar = await response.json();
-      setGeneratedAvatar(avatar.avatar_url);
 
-      // 新しいアバターURLをユーザー情報に反映
-      setCurrentUser((prevUser) => ({
-        ...prevUser,
-        avatars: [...prevUser.avatars, avatar],
-        current_avatar_url: avatar.avatar_url,
-      }));
+      if (response.ok) {
+        const updatedUser = await response.json();
+        setCurrentUser(updatedUser);
+        setGeneratedAvatar(updatedUser.current_avatar_url);
+      } else {
+        const errorData = await response.json();
+        console.error("アバター生成処理に失敗しました:", errorData.error);
+      }
 
       setSelectedJob("未選択");
     } catch (error) {
-      console.error("アバター生成に失敗しました:", error);
+      console.error("アバター生成処理に失敗しました:", error);
     } finally {
       setLoadingAvatar(false);
     }
@@ -192,17 +232,6 @@ export const CreateAvatar = () => {
     );
   }
 
-  //Xシェア機能は外にコード切り出し
-  // const handleTweet = () => {
-  //   const baseUrl = "https://mao-the-3rd-day.s3.ap-northeast-1.amazonaws.com/";
-  //   const imagePath = generatedAvatar.replace(baseUrl, "");
-  //   const tweetText = `魔王を討伐するためにアバターを作りました！ #みかまお`;
-  //   const twitterUrl = `https://twitter.com/intent/tweet?url=${encodeURIComponent(
-  //     `${FRONT_URL}/public_avatar?image=${imagePath}`
-  //   )}&text=${encodeURIComponent(tweetText)}`;
-
-  //   window.open(twitterUrl, "_blank");
-  // };
 
   return (
     <div className="container mx-auto p-4 max-w-5xl min-h-screen">

--- a/frontend/src/pages/MyPage.jsx
+++ b/frontend/src/pages/MyPage.jsx
@@ -470,21 +470,21 @@ export const MyPage = () => {
             className={`tab ${activitiesTab === "entry" ? "tab-active" : ""}`}
             onClick={() => setActivitiesTab("entry")}
           >
-            今日の活動登録
+            今日の活動
           </a>
           <a
             role="tab"
             className={`tab ${activitiesTab === "show" ? "tab-active" : ""}`}
             onClick={() => setActivitiesTab("show")}
           >
-            これまでの活動履歴
+            活動履歴
           </a>
           <a
             role="tab"
             className={`tab ${activitiesTab === "chart" ? "tab-active" : ""}`}
             onClick={() => setActivitiesTab("chart")}
           >
-            活動推移グラフ
+            活動グラフ
           </a>
         </div>
         {activitiesTab === "entry" && (

--- a/frontend/src/providers/auth.jsx
+++ b/frontend/src/providers/auth.jsx
@@ -45,6 +45,8 @@ export const AuthProvider = ({ children }) => {
     }
   }, [token]);
 
+  
+
   const logout = () => {
     setCurrentUser(null); // ユーザー情報をクリア
     setToken(""); // トークンをクリア


### PR DESCRIPTION
活動記録時にactivities, users, user_statusesの非同期処理を連続で行なっていたが、途中で処理を失敗した時に不整合が発生するので、バックへのfetchを一回にまとめ、バック側でtransactionで全ての処理を行うようにした。処理失敗時はロールバックが保証される。
同様に、アバター生成時にアイテムを消費する処理もtransactionにした